### PR TITLE
Fix the size of hologram (onboarding) cause by Tailwind CSS global styles

### DIFF
--- a/packages/suite/src/views/onboarding/steps/Hologram/components/Hologram.tsx
+++ b/packages/suite/src/views/onboarding/steps/Hologram/components/Hologram.tsx
@@ -20,7 +20,7 @@ const Hologram = (props: Props) => {
     };
     return (
         <video
-            height="248px"
+            className="h-[248px] mx-auto"
             autoPlay
             loop={videos[props.model].loop}
             data-test={`@onboarding/hologram/model-${props.model}-video`}


### PR DESCRIPTION
**File**: `Hologram.tsx`
**UI Position**: Onboarding
**Problem**: CSS override
**Method**: Use `class` instead of property to style images.