### PR TITLE
Fix Styles: Onboarding device size

### DIFF
--- a/packages/components/src/components/prompts/ConfirmOnDevice/index.tsx
+++ b/packages/components/src/components/prompts/ConfirmOnDevice/index.tsx
@@ -135,7 +135,7 @@ const ConfirmOnDevice = ({
     return (
         <Wrapper animated={animated} animation={animation}>
             <Left>
-                <DeviceImage height="34px" trezorModel={trezorModel} />
+                <DeviceImage className="h-[34px]" trezorModel={trezorModel} />
             </Left>
             <Middle>
                 <Title>{title}</Title>


### PR DESCRIPTION
Fix the missing height of the device image cause by Tailwind CSS global styles override.

Component：`DeviceImage`
Locaition：Onboarding (Device settings)